### PR TITLE
Also detect 'connectior reset by peer' which is what a unix socket says

### DIFF
--- a/session.go
+++ b/session.go
@@ -330,7 +330,7 @@ func (s *Session) recv() {
 	for {
 		// Read the header
 		if _, err := io.ReadFull(s.bufRead, hdr); err != nil {
-			if err != io.EOF && !strings.Contains(err.Error(), "closed") {
+			if err != io.EOF && !strings.Contains(err.Error(), "closed") && !strings.Contains(err.Error(), "reset by peer") {
 				s.logger.Printf("[ERR] yamux: Failed to read header: %v", err)
 			}
 			s.exitErr(err)


### PR DESCRIPTION
Without this, yamux prints out errors when a unix socket is disconnected.
