### PR TITLE
Fixes read/write loop and ping deadlocks

### DIFF
--- a/const.go
+++ b/const.go
@@ -29,6 +29,10 @@ var (
 	// ErrReceiveWindowExceeded indicates the window was exceeded
 	ErrRecvWindowExceeded = fmt.Errorf("recv window exceeded")
 
+	// ErrHeaderWriteTimeout indicates that we hit an IO deadline waiting
+	// for a header to be written.
+	ErrHeaderWriteTimeout = fmt.Errorf("header write timeout")
+
 	// ErrTimeout is used when we reach an IO deadline
 	ErrTimeout = fmt.Errorf("i/o deadline reached")
 

--- a/mux.go
+++ b/mux.go
@@ -20,6 +20,12 @@ type Config struct {
 	// KeepAliveInterval is how often to perform the keep alive
 	KeepAliveInterval time.Duration
 
+	// HeaderWriteTimeout is how long we will wait to perform a blocking
+	// operation writing a header, after which we will throw an error and
+	// close the stream. Headers are small, so this should be set to a value
+	// after which you suspect there is something wrong with the connection.
+	HeaderWriteTimeout time.Duration
+
 	// MaxStreamWindowSize is used to control the maximum
 	// window size that we allow for a stream.
 	MaxStreamWindowSize uint32
@@ -34,6 +40,7 @@ func DefaultConfig() *Config {
 		AcceptBacklog:       256,
 		EnableKeepAlive:     true,
 		KeepAliveInterval:   30 * time.Second,
+		HeaderWriteTimeout:  10 * time.Second,
 		MaxStreamWindowSize: initialStreamWindow,
 		LogOutput:           os.Stderr,
 	}

--- a/session.go
+++ b/session.go
@@ -501,6 +501,7 @@ func (s *Session) handlePing(hdr header) error {
 				s.logger.Printf("[WARN] yamux: failed to send ping reply: %v", err)
 			}
 		}()
+		return nil
 	}
 
 	// Handle a response

--- a/session_test.go
+++ b/session_test.go
@@ -44,7 +44,7 @@ func testClientServer() (*Session, *Session) {
 	conf := DefaultConfig()
 	conf.AcceptBacklog = 64
 	conf.KeepAliveInterval = 100 * time.Millisecond
-	conf.HeaderWriteTimeout = 100 * time.Millisecond
+	conf.HeaderWriteTimeout = 250 * time.Millisecond
 	return testClientServerConfig(conf)
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -811,7 +811,7 @@ func TestWindowUpdateWriteDuringRead(t *testing.T) {
 	defer client.Close()
 	defer server.Close()
 
-	wg := &sync.WaitGroup{}
+	var wg sync.WaitGroup
 	wg.Add(2)
 
 	// Choose a huge flood size that we know will result in a window update.


### PR DESCRIPTION
If you take out the timeout, the unit test will deadlock when the `Read()` call tries to send the window update. I'm not sure I like the special-case body check in here but I thought I'd push it up so you can take a look (if there's a body we already have an optional deadline interface outside of here).