### PR TITLE
Generalizes the header write timeout to a broader "safety valve" write timeout.

### DIFF
--- a/const.go
+++ b/const.go
@@ -29,10 +29,6 @@ var (
 	// ErrReceiveWindowExceeded indicates the window was exceeded
 	ErrRecvWindowExceeded = fmt.Errorf("recv window exceeded")
 
-	// ErrHeaderWriteTimeout indicates that we hit an IO deadline waiting
-	// for a header to be written.
-	ErrHeaderWriteTimeout = fmt.Errorf("header write timeout")
-
 	// ErrTimeout is used when we reach an IO deadline
 	ErrTimeout = fmt.Errorf("i/o deadline reached")
 
@@ -48,6 +44,10 @@ var (
 	// ErrConnectionReset is sent if a stream is reset. This can happen
 	// if the backlog is exceeded, or if there was a remote GoAway.
 	ErrConnectionReset = fmt.Errorf("connection reset")
+
+	// ErrConnectionWriteTimeout indicates that we hit the "safety valve"
+	// timeout writing to the underlying stream connection.
+	ErrConnectionWriteTimeout = fmt.Errorf("connection write timeout")
 )
 
 const (

--- a/mux.go
+++ b/mux.go
@@ -20,11 +20,11 @@ type Config struct {
 	// KeepAliveInterval is how often to perform the keep alive
 	KeepAliveInterval time.Duration
 
-	// HeaderWriteTimeout is how long we will wait to perform a blocking
-	// operation writing a header, after which we will throw an error and
-	// close the stream. Headers are small, so this should be set to a value
-	// after which you suspect there is something wrong with the connection.
-	HeaderWriteTimeout time.Duration
+	// ConnectionWriteTimeout is meant to be a "safety valve" timeout after
+	// we which will suspect a problem with the underlying connection and
+	// close it. This is only applied to writes, where's there's generally
+	// an expectation that things will move along quickly.
+	ConnectionWriteTimeout time.Duration
 
 	// MaxStreamWindowSize is used to control the maximum
 	// window size that we allow for a stream.
@@ -37,12 +37,12 @@ type Config struct {
 // DefaultConfig is used to return a default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		AcceptBacklog:       256,
-		EnableKeepAlive:     true,
-		KeepAliveInterval:   30 * time.Second,
-		HeaderWriteTimeout:  10 * time.Second,
-		MaxStreamWindowSize: initialStreamWindow,
-		LogOutput:           os.Stderr,
+		AcceptBacklog:          256,
+		EnableKeepAlive:        true,
+		KeepAliveInterval:      30 * time.Second,
+		ConnectionWriteTimeout: 10 * time.Second,
+		MaxStreamWindowSize:    initialStreamWindow,
+		LogOutput:              os.Stderr,
 	}
 }
 


### PR DESCRIPTION
This opens up the timeout to the user's payloads as well as just control headers. It's a little indirect because we don't have a timeout in the `send()` goroutine directly, but this timeout effectively covers that because the caller is waiting for that goroutine to put the write error onto the error feedback channel.