### PR TITLE
Properly handles closing streams before they are ACKed.

### DIFF
--- a/session.go
+++ b/session.go
@@ -178,7 +178,7 @@ GET_ID:
 		select {
 		case <-s.synCh:
 		default:
-			s.logger.Printf("[ERR] aborted stream open without inflight syn semaphore")
+			s.logger.Printf("[ERR] yamux: aborted stream open without inflight syn semaphore")
 		}
 		return nil, err
 	}
@@ -598,7 +598,7 @@ func (s *Session) closeStream(id uint32) {
 		select {
 		case <-s.synCh:
 		default:
-			s.logger.Printf("[ERR] un-established stream without inflight syn semaphore")
+			s.logger.Printf("[ERR] yamux: un-established stream without inflight syn semaphore")
 		}
 	}
 	delete(s.streams, id)
@@ -612,12 +612,12 @@ func (s *Session) establishStream(id uint32) {
 	if _, ok := s.inflight[id]; ok {
 		delete(s.inflight, id)
 	} else {
-		s.logger.Printf("[ERR] established stream without inflight syn entry")
+		s.logger.Printf("[ERR] yamux: established stream without inflight syn entry")
 	}
 	select {
 	case <-s.synCh:
 	default:
-		s.logger.Printf("[ERR] established stream without inflight syn semaphore")
+		s.logger.Printf("[ERR] yamux: established stream without inflight syn semaphore")
 	}
 	s.streamLock.Unlock()
 }

--- a/session.go
+++ b/session.go
@@ -46,8 +46,11 @@ type Session struct {
 	pingID   uint32
 	pingLock sync.Mutex
 
-	// streams maps a stream id to a stream
+	// streams maps a stream id to a stream, and inflight has an entry
+	// for any outgoing stream that has not yet been established. Both are
+	// protected by streamLock.
 	streams    map[uint32]*Stream
+	inflight   map[uint32]struct{}
 	streamLock sync.Mutex
 
 	// synCh acts like a semaphore. It is sized to the AcceptBacklog which
@@ -90,6 +93,7 @@ func newSession(config *Config, conn io.ReadWriteCloser, client bool) *Session {
 		bufRead:    bufio.NewReader(conn),
 		pings:      make(map[uint32]chan struct{}),
 		streams:    make(map[uint32]*Stream),
+		inflight:   make(map[uint32]struct{}),
 		synCh:      make(chan struct{}, config.AcceptBacklog),
 		acceptCh:   make(chan *Stream, config.AcceptBacklog),
 		sendCh:     make(chan sendReady, 64),
@@ -153,7 +157,7 @@ func (s *Session) OpenStream() (*Stream, error) {
 	}
 
 GET_ID:
-	// Get and ID, and check for stream exhaustion
+	// Get an ID, and check for stream exhaustion
 	id := atomic.LoadUint32(&s.nextStreamID)
 	if id >= math.MaxUint32-1 {
 		return nil, ErrStreamsExhausted
@@ -166,6 +170,7 @@ GET_ID:
 	stream := newStream(s, id, streamInit)
 	s.streamLock.Lock()
 	s.streams[id] = stream
+	s.inflight[id] = struct{}{}
 	s.streamLock.Unlock()
 
 	// Send the window update to create
@@ -580,19 +585,34 @@ func (s *Session) incomingStream(id uint32) error {
 }
 
 // closeStream is used to close a stream once both sides have
-// issued a close.
+// issued a close. If there was an in-flight SYN and the stream
+// was not yet established, then this will give the credit back.
 func (s *Session) closeStream(id uint32) {
 	s.streamLock.Lock()
+	if _, ok := s.inflight[id]; ok {
+		select {
+		case <-s.synCh:
+		default:
+			s.logger.Printf("[ERR] un-established stream without inflight syn semaphore")
+		}
+	}
 	delete(s.streams, id)
 	s.streamLock.Unlock()
 }
 
 // establishStream is used to mark a stream that was in the
 // SYN Sent state as established.
-func (s *Session) establishStream() {
+func (s *Session) establishStream(id uint32) {
+	s.streamLock.Lock()
+	if _, ok := s.inflight[id]; ok {
+		delete(s.inflight, id)
+	} else {
+		s.logger.Printf("[ERR] established stream without inflight syn entry")
+	}
 	select {
 	case <-s.synCh:
 	default:
-		panic("established stream without inflight syn")
+		s.logger.Printf("[ERR] established stream without inflight syn semaphore")
 	}
+	s.streamLock.Unlock()
 }

--- a/session.go
+++ b/session.go
@@ -598,7 +598,7 @@ func (s *Session) closeStream(id uint32) {
 		select {
 		case <-s.synCh:
 		default:
-			s.logger.Printf("[ERR] yamux: un-established stream without inflight syn semaphore")
+			s.logger.Printf("[ERR] yamux: SYN tracking out of sync")
 		}
 	}
 	delete(s.streams, id)
@@ -612,12 +612,12 @@ func (s *Session) establishStream(id uint32) {
 	if _, ok := s.inflight[id]; ok {
 		delete(s.inflight, id)
 	} else {
-		s.logger.Printf("[ERR] yamux: established stream without inflight syn entry")
+		s.logger.Printf("[ERR] yamux: established stream without inflight SYN (no tracking entry)")
 	}
 	select {
 	case <-s.synCh:
 	default:
-		s.logger.Printf("[ERR] yamux: established stream without inflight syn semaphore")
+		s.logger.Printf("[ERR] yamux: established stream without inflight SYN (didn't have semaphore)")
 	}
 	s.streamLock.Unlock()
 }

--- a/session.go
+++ b/session.go
@@ -175,6 +175,11 @@ GET_ID:
 
 	// Send the window update to create
 	if err := stream.sendWindowUpdate(); err != nil {
+		select {
+		case <-s.synCh:
+		default:
+			s.logger.Printf("[ERR] aborted stream open without inflight syn semaphore")
+		}
 		return nil, err
 	}
 	return stream, nil


### PR DESCRIPTION
This takes #28 which fixes #26 but puts all the logic on the side opening the stream, so we don't depend on any updated logic or messages from the other side. In addition:

* Modified the logic to clean up the `synCh` when a stream is established (like before) and any time a stream is closed. This latter change is easier to reason about, and we don't have to trace through every possible close scenario to make sure we catch them all.
* Changed the `panic()`s in the `synCh` handling code to `ERR` logs, since underflowing that channel _could_ happen from a misbehaving client on the other side sending extra ACKs. Also, this is recoverable, so we don't need to panic.
* Added some cleanup code for `synCh` if the initial window update can't be sent.