### PR TITLE
use a timer instead of 'After' to avoid leaking resources

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -118,12 +118,17 @@ START:
 
 WAIT:
 	var timeout <-chan time.Time
+	var timer *time.Timer
 	if !s.readDeadline.IsZero() {
 		delay := s.readDeadline.Sub(time.Now())
-		timeout = time.After(delay)
+		timer = time.NewTimer(delay)
+		timeout = timer.C
 	}
 	select {
 	case <-s.recvNotifyCh:
+		if timer != nil {
+			timer.Stop()
+		}
 		goto START
 	case <-timeout:
 		return 0, ErrTimeout


### PR DESCRIPTION
Calling time.After creates a runtime timer that gets scheduled into the runtime. Doing this frequently will bog the scheduler down and have weird effects on the program. Using a timer instead will let us stop the timer and free up those resources when we exit the function