### PR TITLE
Fix race for recvBuf

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -91,10 +91,13 @@ START:
 	case streamRemoteClose:
 		fallthrough
 	case streamClosed:
+		s.recvLock.Lock()
 		if s.recvBuf == nil || s.recvBuf.Len() == 0 {
+			s.recvLock.Unlock()
 			s.stateLock.Unlock()
 			return 0, io.EOF
 		}
+		s.recvLock.Unlock()
 	case streamReset:
 		s.stateLock.Unlock()
 		return 0, ErrConnectionReset


### PR DESCRIPTION
This is a race condition found running my own code with `-race`. Running the tests for this library with `-race` results in many, what I think are probably not important, race conditions and fails some tests. So writing a test case for this is impossible with the current state of the tests.

From what I can see no other place tries to lock `recvLock` and `stateLock` at the same time so this shouldn't introduce any deadlocks.