### PR TITLE
optimize ping : if the data is flowing into recvLoop, ping is not required

### DIFF
--- a/session.go
+++ b/session.go
@@ -305,15 +305,13 @@ func (s *Session) keepalive() {
 	for {
 		select {
 		case <-time.After(s.config.KeepAliveInterval):
-			if atomic.LoadInt32(&s.needPing) == 0 {
+			if !atomic.CompareAndSwapInt32(&s.needPing, 1, 0) {
 				_, err := s.Ping()
 				if err != nil {
 					s.logger.Printf("[ERR] yamux: keepalive failed: %v", err)
 					s.exitErr(ErrKeepAliveTimeout)
 					return
 				}
-			} else {
-				atomic.StoreInt32(&s.needPing, 0)
 			}
 		case <-s.shutdownCh:
 			return


### PR DESCRIPTION
consider the following situation:
1. a link has 200KB/s bandwidth, and the underlying socket buffer is 4MB(large enough)
2. set yamux.Config MaxStreamWindowSize to sockbuf(large enough)
3. constantly send data via streams, eg : 2MB/s to make the socket buffer full
4. then the keepalive cannot respond in 10seconds ( 2MB/200KB)

I think we don't need to send ping packets when the data is flowing to the receiver.
