### PR TITLE
Fix the ping test by adding a delay to the write operation

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -2,10 +2,13 @@ package yamux
 
 import (
 	"testing"
+	"time"
 )
 
 func BenchmarkPing(b *testing.B) {
 	client, server := testClientServer()
+	client.conn = &delayedConn{conn: client.conn, writeDelay: 10 * time.Millisecond}
+	server.conn = &delayedConn{conn: server.conn, writeDelay: 10 * time.Millisecond}
 	defer client.Close()
 	defer server.Close()
 


### PR DESCRIPTION
The `TestPing` unit test failed on my machine since it always reported a rtt of 0. I guess that is since the Go timers are not very accurate on windows and writing through pipes **is** really fast.

I fixed that now by introducing a delay/sleep to the write.
It's a little hacky since I grab and modify the connection from the session which would be unsafe if it sends anything while not externally called. But I think it doesn't do that as long as there are not streams, pings or keepalives running and works for that test.

The other alternative is to introduce a general delay option to pipeConn which I did first. But there unit tests need to be modified in lots of places to set that new parameter.
