### PR TITLE
Add public session CloseChan method

### DIFF
--- a/session.go
+++ b/session.go
@@ -123,6 +123,12 @@ func (s *Session) IsClosed() bool {
 	}
 }
 
+// CloseChan returns a read-only channel which is closed as
+// soon as the session is closed.
+func (s *Session) CloseChan() <-chan struct{} {
+	return s.shutdownCh
+}
+
 // NumStreams returns the number of currently open streams
 func (s *Session) NumStreams() int {
 	s.streamLock.Lock()

--- a/session_test.go
+++ b/session_test.go
@@ -619,7 +619,7 @@ func TestHalfClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, err := stream.Write([]byte("a")); err != nil {
+	if _, err = stream.Write([]byte("a")); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -639,7 +639,7 @@ func TestHalfClose(t *testing.T) {
 	}
 
 	// Send more
-	if _, err := stream.Write([]byte("bcd")); err != nil {
+	if _, err = stream.Write([]byte("bcd")); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	stream.Close()

--- a/stream.go
+++ b/stream.go
@@ -188,7 +188,7 @@ START:
 
 	// Send the header
 	s.sendHdr.encode(typeData, flags, s.id, max)
-	if err := s.session.waitForSendErr(s.sendHdr, body, s.sendErr); err != nil {
+	if err = s.session.waitForSendErr(s.sendHdr, body, s.sendErr); err != nil {
 		return 0, err
 	}
 


### PR DESCRIPTION
I commonly use the following style to wait until a connection closes to handle further cleanup...

```go
go func() {
	<-session.CloseChan()
	// Do some cleanup, close other parent connections...
}()
```

Would be great to see this feature upstream.