### PR TITLE
don't block writes after session has shut down

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -209,6 +209,8 @@ WAIT:
 		goto START
 	case <-timeout:
 		return 0, ErrTimeout
+	case <-s.session.shutdownCh:
+		return 0, ErrSessionShutdown
 	}
 	return 0, nil
 }


### PR DESCRIPTION
This should address the issues in #45 . I've applied this to my machine thats been able to semi-reliably reproduce the issue, so we'll see if it crops up again.