### PR TITLE
Add timeout support to stream acceptance

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -273,6 +273,20 @@ func TestAccept(t *testing.T) {
 	}
 }
 
+func TestAcceptTimeout(t *testing.T) {
+	client, server := testClientServer()
+	defer client.Close()
+	defer server.Close()
+
+	session, err := client.AcceptStreamWithTimeout(1 * time.Microsecond)
+	if err != ErrTimeout {
+		t.Fatalf("bad: %v", err)
+	}
+	if session != nil {
+		t.Fatalf("bad: %v", session)
+	}
+}
+
 func TestNonNilInterface(t *testing.T) {
 	_, server := testClientServer()
 	server.Close()


### PR DESCRIPTION
Add timeout support to stream acceptance:

``` Go
stream, err := s.AcceptStreamWithTimeout(50 * time.Millisecond)
```

We use this to accept streams within a certain time or close the connection. It will block forever when called with an zero duration. Timers will be closed so it is recovered by the garbage collector even if the timer has not been fired yet.