### PR TITLE
Add a callback for keepalive failure

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -46,6 +46,7 @@ func DefaultConfig() *Config {
 		ConnectionWriteTimeout: 10 * time.Second,
 		MaxStreamWindowSize:    initialStreamWindow,
 		LogOutput:              os.Stderr,
+		OnKeepAliveFail:        func() {},
 	}
 }
 

--- a/mux.go
+++ b/mux.go
@@ -32,6 +32,9 @@ type Config struct {
 
 	// LogOutput is used to control the log destination
 	LogOutput io.Writer
+
+	// Called when a keepalive fails and the connection is terminated
+	OnKeepAliveFail func()
 }
 
 // DefaultConfig is used to return a default configuration

--- a/session.go
+++ b/session.go
@@ -304,6 +304,7 @@ func (s *Session) keepalive() {
 			_, err := s.Ping()
 			if err != nil {
 				s.logger.Printf("[ERR] yamux: keepalive failed: %v", err)
+				s.config.OnKeepAliveFail()
 				s.exitErr(ErrKeepAliveTimeout)
 				return
 			}


### PR DESCRIPTION
I've found this useful to notify my code of a disconnect, and it actually means I don't need to implement my own heartbeat/keepalive (which seems pointless considering yamux already does)