### PR TITLE
Dont output keepalive error when the session is closed

### DIFF
--- a/session.go
+++ b/session.go
@@ -309,8 +309,10 @@ func (s *Session) keepalive() {
 		case <-time.After(s.config.KeepAliveInterval):
 			_, err := s.Ping()
 			if err != nil {
-				s.logger.Printf("[ERR] yamux: keepalive failed: %v", err)
-				s.exitErr(ErrKeepAliveTimeout)
+				if err != ErrSessionShutdown {
+					s.logger.Printf("[ERR] yamux: keepalive failed: %v", err)
+					s.exitErr(ErrKeepAliveTimeout)
+				}
 				return
 			}
 		case <-s.shutdownCh:


### PR DESCRIPTION
The keepalive runs in its own go routine and its likely the session gets closed out from under it. In this case we should not output an error but rather should handle it like the next case in the select below which is to just return.