### PR TITLE
Session.recvLoop(): Improve sanity checking of message types.

### DIFF
--- a/session.go
+++ b/session.go
@@ -464,7 +464,7 @@ func (s *Session) recvLoop() error {
 		}
 
 		mt := hdr.MsgType()
-		if mt < typeData || mt > typeGoAway {
+		if int(mt) >= len(handlers) || handlers[mt] == nil {
 			return ErrInvalidMsgType
 		}
 


### PR DESCRIPTION
Initializing a sparse slice and then only checking upper and lower bounds is a null pointer dereference waiting to happen. Also, explicitly listing the lowest and highest identifier is brittle and prone to break
in the future.