### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/yamux


### PR DESCRIPTION
This adds a `go.mod` file. I'm going to just merge this immediately since yamux has no dependencies and therefore adding the go.mod has zero downside.