### PR TITLE
Fix hashicorp/yamux#72, abstract logger into interface

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -3,7 +3,6 @@ package yamux
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"time"
 )
@@ -37,7 +36,7 @@ type Config struct {
 
 	// Logger is used to pass in the logger to be used. Either Logger or
 	// LogOutput can be set, not both.
-	Logger *log.Logger
+	Logger Logger
 }
 
 // DefaultConfig is used to return a default configuration

--- a/session.go
+++ b/session.go
@@ -33,7 +33,7 @@ type Session struct {
 	config *Config
 
 	// logger is used for our logs
-	logger *log.Logger
+	logger Logger
 
 	// conn is the underlying connection
 	conn io.ReadWriteCloser

--- a/util.go
+++ b/util.go
@@ -5,6 +5,13 @@ import (
 	"time"
 )
 
+// Logger is a abstract of *log.Logger
+type Logger interface {
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
+}
+
 var (
 	timerPool = &sync.Pool{
 		New: func() interface{} {


### PR DESCRIPTION
*log.Logger is not a good choice as a parameter.