### PR TITLE
fix failing test

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -439,7 +439,6 @@ func TestSendData_Large(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 	}()
-
 	doneCh := make(chan struct{})
 	go func() {
 		wg.Wait()
@@ -447,6 +446,7 @@ func TestSendData_Large(t *testing.T) {
 	}()
 	select {
 	case <-doneCh:
+		return
 	case <-time.After(5 * time.Second):
 		panic("timeout")
 	}


### PR DESCRIPTION


fixing failing test in go 1.12 :
see https://github.com/hashicorp/yamux/issues/71

```
19:15:03/Users/pierrot/dev/yamuxλ go test --count=1 ./...
2019/05/12 19:15:16 [ERR] yamux: keepalive failed: i/o deadline reached
--- FAIL: TestSendData_Large (0.40s)
    session_test.go:427: err: session shutdown
    session_test.go:396: err: EOF
2019/05/12 19:15:16 [WARN] yamux: failed to send ping reply: session shutdown
2019/05/12 19:15:24 [WARN] yamux: failed to send ping reply: connection write timeout
FAIL
FAIL	github.com/hashicorp/yamux	9.505s
19:15:25/Users/pierrot/dev/yamuxλ git checkout -
M	go.mod
Switched to branch 'fix_test'
Your branch is up-to-date with 'pmalhaire/fix_test'.
19:15:56/Users/pierrot/dev/yamuxλ go test --count=1 ./...
ok  	github.com/hashicorp/yamux	9.911s
```