### PR TITLE
Deadline updates impact blocked reads and writes

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -446,15 +446,17 @@ func (s *Stream) SetDeadline(t time.Time) error {
 	return nil
 }
 
-// SetReadDeadline sets the deadline for future Read calls.
+// SetReadDeadline sets the deadline for blocked and future Read calls.
 func (s *Stream) SetReadDeadline(t time.Time) error {
 	s.readDeadline.Store(t)
+	asyncNotify(s.recvNotifyCh)
 	return nil
 }
 
-// SetWriteDeadline sets the deadline for future Write calls
+// SetWriteDeadline sets the deadline for blocked and future Write calls
 func (s *Stream) SetWriteDeadline(t time.Time) error {
 	s.writeDeadline.Store(t)
+	asyncNotify(s.sendNotifyCh)
 	return nil
 }
 


### PR DESCRIPTION
This change causes new deadlines to impact currently blocked reads and
writes. This is inline with the documentation of deadlines on a
[net.Conn](https://golang.org/pkg/net/#Conn).

This PR can close #https://github.com/hashicorp/yamux/pull/51