### PR TITLE
Add support for closing write ends of streams

### DIFF
--- a/const.go
+++ b/const.go
@@ -35,6 +35,9 @@ var (
 	// ErrStreamClosed is returned when using a closed stream
 	ErrStreamClosed = fmt.Errorf("stream closed")
 
+	// ErrWriteClosed is returned when using a closed write end of a stream
+	ErrWriteClosed = fmt.Errorf("write end of stream closed")
+
 	// ErrUnexpectedFlag is set when we get an unexpected flag
 	ErrUnexpectedFlag = fmt.Errorf("unexpected flag")
 
@@ -93,6 +96,11 @@ const (
 
 	// RST is used to hard close a given stream.
 	flagRST
+
+	// flagCloseWrite is sent to notify the remote end
+	// that no more data will be written to the stream.
+	// May be sent with a data payload.
+	flagCloseWrite
 )
 
 const (

--- a/session_test.go
+++ b/session_test.go
@@ -1351,3 +1351,34 @@ func TestSession_ConnectionWriteTimeout(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestCloseWrite(t *testing.T) {
+	client, server := testClientServer()
+	defer client.Close()
+	defer server.Close()
+
+	stream, err := client.OpenStream()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer stream.Close()
+
+	stream2, err := server.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer stream2.Close()
+
+	if _, err := stream.Write([]byte("test")); err != nil {
+		t.Fatal(err)
+	} else if err := stream.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ioutil.ReadAll(stream2)
+	if err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(data, []byte("test")) {
+		t.Fatalf("got data %q, want %q", data, "test")
+	}
+}


### PR DESCRIPTION
When sending payloads of unknown length over a Stream
and expecting the server to read it to completion before
emitting a response (such as forwarding a byte stream),
one difficulty with yamux is communicating that the byte
stream's end has been reached.

One approach is to introduce a higher-level protocol,
but when the byte stream is of unknown size this requires
essentially reimplementing large parts of yamux's framing
protocol.

A simpler solution is to communicate that EOF has been reached.
Yamux provides this capability through (*Stream).Close,
but it closes both the read and the write ends, which then
prevents the client from reading the response from the server.

This change introduces a new method, (*Stream).CloseWrite,
which only closes the write end of the stream. When encountered
on the other end, it sets a flag that the remote's write end has been
closed and begins returning EOF from any reads after the receive
buffer has been exhausted.