### PR TITLE
Don't verify KeepAliveInterval when keep alive is not enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/hashicorp/yamux
+module github.com/hexian000/yamux
 
 go 1.15

--- a/mux.go
+++ b/mux.go
@@ -73,7 +73,7 @@ func VerifyConfig(config *Config) error {
 	if config.AcceptBacklog <= 0 {
 		return fmt.Errorf("backlog must be positive")
 	}
-	if config.KeepAliveInterval == 0 {
+	if config.EnableKeepAlive && config.KeepAliveInterval <= 0 {
 		return fmt.Errorf("keep-alive interval must be positive")
 	}
 	if config.MaxStreamWindowSize < initialStreamWindow {

--- a/session.go
+++ b/session.go
@@ -328,7 +328,7 @@ func (s *Session) Ping() (time.Duration, error) {
 	}
 
 	// Compute the RTT
-	return time.Now().Sub(start), nil
+	return time.Since(start), nil
 }
 
 // keepalive is a long running goroutine that periodically does

--- a/stream.go
+++ b/stream.go
@@ -134,7 +134,7 @@ WAIT:
 	var timer *time.Timer
 	readDeadline := s.readDeadline.Load().(time.Time)
 	if !readDeadline.IsZero() {
-		delay := readDeadline.Sub(time.Now())
+		delay := time.Until(readDeadline)
 		timer = time.NewTimer(delay)
 		timeout = timer.C
 	}
@@ -213,7 +213,7 @@ WAIT:
 	var timeout <-chan time.Time
 	writeDeadline := s.writeDeadline.Load().(time.Time)
 	if !writeDeadline.IsZero() {
-		delay := writeDeadline.Sub(time.Now())
+		delay := time.Until(writeDeadline)
 		timeout = time.After(delay)
 	}
 	select {
@@ -222,7 +222,6 @@ WAIT:
 	case <-timeout:
 		return 0, ErrTimeout
 	}
-	return 0, nil
 }
 
 // sendFlags determines any flags that are appropriate


### PR DESCRIPTION
This commit prevents unnecessary errors when calling yamux.Client.