### PR TITLE
Implement timeouts for OpenStream

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -31,6 +31,11 @@ type Config struct {
 	// window size that we allow for a stream.
 	MaxStreamWindowSize uint32
 
+	// StreamOpenTimeout is the maximum amount of time that a stream will
+	// be allowed to remain open until it is ACKed.
+	// Once the timeout is reached the session will be gracefully closed.
+	StreamOpenTimeout time.Duration
+
 	// StreamCloseTimeout is the maximum time that a stream will allowed to
 	// be in a half-closed state when `Close` is called before forcibly
 	// closing the connection. Forcibly closed connections will empty the
@@ -56,6 +61,7 @@ func DefaultConfig() *Config {
 		ConnectionWriteTimeout: 10 * time.Second,
 		MaxStreamWindowSize:    initialStreamWindow,
 		StreamCloseTimeout:     5 * time.Minute,
+		StreamOpenTimeout:      30 * time.Second,
 		LogOutput:              os.Stderr,
 	}
 }

--- a/session.go
+++ b/session.go
@@ -184,6 +184,10 @@ GET_ID:
 	s.inflight[id] = struct{}{}
 	s.streamLock.Unlock()
 
+	if s.config.StreamOpenTimeout > 0 {
+		go s.setOpenTimeout(stream)
+	}
+
 	// Send the window update to create
 	if err := stream.sendWindowUpdate(); err != nil {
 		select {
@@ -194,6 +198,27 @@ GET_ID:
 		return nil, err
 	}
 	return stream, nil
+}
+
+// setOpenTimeout implements a timeout for streams that are opened but not established.
+// If the StreamOpenTimeout is exceeded we assume the server is unable to ACK,
+// and close the session.
+// The number of running timers is bounded by the capacity of the synCh.
+func (s *Session) setOpenTimeout(stream *Stream) {
+	timer := time.NewTimer(s.config.StreamOpenTimeout)
+	defer timer.Stop()
+
+	select {
+	case <-stream.establishCh:
+		return
+	case <-s.shutdownCh:
+		return
+	case <-timer.C:
+		// Timeout reached while waiting for ACK.
+		// Close the session to force connection re-establishment.
+		s.logger.Printf("[ERR] yamux: aborted stream open (destination=%s): %v", s.RemoteAddr().String(), ErrTimeout.err)
+		s.Close()
+	}
 }
 
 // Accept is used to block until the next available stream


### PR DESCRIPTION
Currently streams can be in the streamSYNSent state for an unbounded
amount of time when the remote is unable to reply and has not closed the
connection via FIN/RST.

This commit adds a deadline to receiving an ACK after a SYN is sent on
OpenStream.

The timeout is opt-in only and configurable per-session with StreamOpenTimeout.
When the timeout is triggered, an error is logged.

Note that the establishCh is buffered and we avoid closing the channel because
there are multiple call-paths that can invoke it: 
- Stream establishment
- Remote close (FIN/RST)
- Local close