### PR TITLE
Remove unnecessary *bytes.Reader in Stream.Write()

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -169,7 +169,7 @@ func (s *Stream) Write(b []byte) (n int, err error) {
 func (s *Stream) write(b []byte) (n int, err error) {
 	var flags uint16
 	var max uint32
-	var body io.Reader
+	var body []byte
 START:
 	s.stateLock.Lock()
 	switch s.state {
@@ -195,7 +195,7 @@ START:
 
 	// Send up to our send window
 	max = min(window, uint32(len(b)))
-	body = bytes.NewReader(b[:max])
+	body = b[:max]
 
 	// Send the header
 	s.sendHdr.encode(typeData, flags, s.id, max)


### PR DESCRIPTION
Prior to this change, each call to Stream.Write() would allocate 1 or
more *bytes.Reader instances. While these are small, it makes the Go
garbage collector do unnecessary work.

Besides the inefficiency at the machine level, it also makes no sense
at the human level to create an io.Reader and use io.Copy when a
single Write() call suffices.