### PR TITLE
Remove unnecessary for loop in Session.send()

### DIFF
--- a/session.go
+++ b/session.go
@@ -425,16 +425,12 @@ func (s *Session) send() {
 		case ready := <-s.sendCh:
 			// Send a header if ready
 			if ready.Hdr != nil {
-				sent := 0
-				for sent < len(ready.Hdr) {
-					n, err := s.conn.Write(ready.Hdr[sent:])
-					if err != nil {
-						s.logger.Printf("[ERR] yamux: Failed to write header: %v", err)
-						asyncSendErr(ready.Err, err)
-						s.exitErr(err)
-						return
-					}
-					sent += n
+				_, err := s.conn.Write(ready.Hdr)
+				if err != nil {
+					s.logger.Printf("[ERR] yamux: Failed to write header: %v", err)
+					asyncSendErr(ready.Err, err)
+					s.exitErr(err)
+					return
 				}
 			}
 


### PR DESCRIPTION
This removes a for loop around io.Writer.Write() calls in
session.send(). The loop looks like what you would write in C when
making write(2) syscalls. With C and write(2), you need to account for
partial writes and call write(2) more than once. This is not how Go's
io.Writer works. The io.Writer contract clearly states that "Write
must return a non-nil error if it returns n < len(p)". Dealing with
partial writes is the responsibility of _implementations_ of
io.Writer, not that of callers.

Removing the for loop makes the code simpler and more idiomatic.