### PR TITLE
Fix use of unprotected `stream.sendHdr` in session

### DIFF
--- a/session.go
+++ b/session.go
@@ -639,8 +639,9 @@ func (s *Session) incomingStream(id uint32) error {
 		// Backlog exceeded! RST the stream
 		s.logger.Printf("[WARN] yamux: backlog exceeded, forcing connection reset")
 		delete(s.streams, id)
-		stream.sendHdr.encode(typeWindowUpdate, flagRST, id, 0)
-		return s.sendNoWait(stream.sendHdr)
+		hdr := header(make([]byte, headerSize))
+		hdr.encode(typeWindowUpdate, flagRST, id, 0)
+		return s.sendNoWait(hdr)
 	}
 }
 


### PR DESCRIPTION
We now create a new header slice instead of taking a `sendLock` as this is a rare occurance.

This should fix some rare race conditions with simultaneous reads/writes to `sendHdr`.

I believe I've identified another potential race condition in `(*Session).waitForSendErr` which might warrant further investigation:

1. `(*Stream).write` calls `(*Session).waitForSendErr`, passing `s.sendHdr` (whilst locked)
2. `(*Session).waitForSendErr` passes `s.sendHdr` on to `(*Session).send` via `s.sendCh` (which is buffered)
3. Send times out (or server shuts down), `waitForSendErr` returns, `write` exists and leaves `s.sendHdr` unprotected
