### PR TITLE
Record actual copied length

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -488,14 +488,15 @@ func (s *Stream) readData(hdr header, flags uint16, conn io.Reader) error {
 		// This way we can read in the whole packet without further allocations.
 		s.recvBuf = bytes.NewBuffer(make([]byte, 0, length))
 	}
-	if _, err := io.Copy(s.recvBuf, conn); err != nil {
+	copiedLength, err := io.Copy(s.recvBuf, conn)
+	if err != nil {
 		s.session.logger.Printf("[ERR] yamux: Failed to read stream data: %v", err)
 		s.recvLock.Unlock()
 		return err
 	}
 
 	// Decrement the receive window
-	s.recvWindow -= length
+	s.recvWindow -= uint32(copiedLength)
 	s.recvLock.Unlock()
 
 	// Unblock any readers


### PR DESCRIPTION
This allows properly recording partial reads on connection break

Partially addresses #94