### PR TITLE
let ErrTimeout temporary

### DIFF
--- a/const.go
+++ b/const.go
@@ -54,7 +54,8 @@ var (
 
 		// Error should meet net.Error interface for timeouts for compatability
 		// with standard library expectations, such as http servers.
-		timeout: true,
+		timeout:   true,
+		temporary: true,
 	}
 
 	// ErrStreamClosed is returned when using a closed stream

--- a/session_test.go
+++ b/session_test.go
@@ -872,7 +872,7 @@ func TestReadDeadline(t *testing.T) {
 	// We assert that we return an error meeting the interface to avoid
 	// accidently breaking yamux session compatability with the standard
 	// library's http server implementation.
-	if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+	if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() || !netErr.Temporary() {
 		t.Fatalf("reading timeout error is expected to implement net.Error and return true when calling Timeout()")
 	}
 }


### PR DESCRIPTION
`ErrTimeout` should be temporary, just like the standard packages in Golang.

```go
// Read header, payload.
if err := c.readFromUntil(c.conn, recordHeaderLen); err != nil {
    // RFC 8446, Section 6.1 suggests that EOF without an alertCloseNotify
    // is an error, but popular web sites seem to do this, so we accept it
    // if and only if at the record boundary.
    if err == io.ErrUnexpectedEOF && c.rawInput.Len() == 0 {
        err = io.EOF
    }
    if e, ok := err.(net.Error); !ok || !e.Temporary() {
        c.in.setErrorLocked(err)
    }
    return err
}
```

When we use tls.Conn to wrap yamux.Stream, if a read deadline occurs, it will cause subsequent read operations to fail continuously because `e.Temporary()` returns false, indicating a permanent error.

@jefferai PTAL