### PR TITLE
chore: update tests to pass the race detector and linter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,41 @@
+name: CI Tests
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+  push:
+    branches:
+      - 'master'
+    paths-ignore:
+      - 'README.md'
+
+permissions:
+  contents: read
+
+jobs:
+  go-fmt-and-vet:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+    - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+      with:
+        go-version: '1.20'
+        cache: true
+    - run: |
+        files=$(go fmt ./...)
+        if [ -n "$files" ]; then
+          echo "The following file(s) do not conform to go fmt:"
+          echo "$files"
+          exit 1
+        fi
+  go-test:
+    needs: go-fmt-and-vet
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+    - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+      with:
+        go-version: '1.20'
+        cache: true
+    - run: |
+        go test -race ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/hashicorp/yamux
 
-go 1.15
+go 1.20

--- a/mux.go
+++ b/mux.go
@@ -53,6 +53,11 @@ type Config struct {
 	Logger Logger
 }
 
+func (c *Config) Clone() *Config {
+	c2 := *c
+	return &c2
+}
+
 // DefaultConfig is used to return a default configuration
 func DefaultConfig() *Config {
 	return &Config{

--- a/session.go
+++ b/session.go
@@ -356,7 +356,7 @@ func (s *Session) Ping() (time.Duration, error) {
 	}
 
 	// Compute the RTT
-	return time.Now().Sub(start), nil
+	return time.Since(start), nil
 }
 
 // keepalive is a long running goroutine that periodically does

--- a/session_test.go
+++ b/session_test.go
@@ -444,7 +444,7 @@ func TestSendData_Small(t *testing.T) {
 
 func TestSendData_Large(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping slow test that times out on the race detector")
+		t.Skip("skipping slow test that may time out on the race detector")
 	}
 	client, server := testClientServer(t)
 
@@ -520,7 +520,7 @@ func TestSendData_Large(t *testing.T) {
 		errCh <- nil
 	}()
 
-	drainErrorsUntil(t, errCh, 2, time.Second, "timeout")
+	drainErrorsUntil(t, errCh, 2, 10*time.Second, "timeout")
 }
 
 func TestGoAway(t *testing.T) {
@@ -1129,7 +1129,7 @@ func (u *UnlimitedReader) Read(p []byte) (int, error) {
 
 func TestSendData_VeryLarge(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping slow test that times out on the race detector")
+		t.Skip("skipping slow test that may time out on the race detector")
 	}
 	client, server := testClientServer(t)
 
@@ -1202,7 +1202,7 @@ func TestSendData_VeryLarge(t *testing.T) {
 	}
 
 	// With the race detector on, this test takes 3-4x longer than this timeout.
-	drainErrorsUntil(t, errCh, workers*2, 20*time.Second, "timeout")
+	drainErrorsUntil(t, errCh, workers*2, 60*time.Second, "timeout")
 }
 
 func TestBacklogExceeded_Accept(t *testing.T) {

--- a/session_test.go
+++ b/session_test.go
@@ -351,12 +351,12 @@ func TestNonNilInterface(t *testing.T) {
 		t.Fatal("bad: accept should return a shutdown error and a connection of nil value")
 	}
 	if err != nil && conn != nil {
-		t.Fatal("bad: accept should return a connection of nil value")
+		t.Error("bad: accept should return a connection of nil value")
 	}
 
 	conn, err = server.Open()
 	if err == nil || !errors.Is(err, ErrSessionShutdown) || conn != nil {
-		t.Fatal("bad: accept should return a shutdown error and a connection of nil value")
+		t.Fatal("bad: open should return a shutdown error and a connection of nil value")
 	}
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -1201,8 +1201,7 @@ func TestSendData_VeryLarge(t *testing.T) {
 		}()
 	}
 
-	// With the race detector on, this test takes 3-4x longer than this timeout.
-	drainErrorsUntil(t, errCh, workers*2, 60*time.Second, "timeout")
+	drainErrorsUntil(t, errCh, workers*2, 120*time.Second, "timeout")
 }
 
 func TestBacklogExceeded_Accept(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -138,7 +138,7 @@ WAIT:
 	var timer *time.Timer
 	readDeadline := s.readDeadline.Load().(time.Time)
 	if !readDeadline.IsZero() {
-		delay := readDeadline.Sub(time.Now())
+		delay := time.Until(readDeadline)
 		timer = time.NewTimer(delay)
 		timeout = timer.C
 	}
@@ -221,7 +221,7 @@ WAIT:
 	var timeout <-chan time.Time
 	writeDeadline := s.writeDeadline.Load().(time.Time)
 	if !writeDeadline.IsZero() {
-		delay := writeDeadline.Sub(time.Now())
+		delay := time.Until(writeDeadline)
 		timeout = time.After(delay)
 	}
 	select {
@@ -230,7 +230,6 @@ WAIT:
 	case <-timeout:
 		return 0, ErrTimeout
 	}
-	return 0, nil
 }
 
 // sendFlags determines any flags that are appropriate
@@ -380,7 +379,7 @@ func (s *Stream) closeTimeout() {
 	defer s.sendLock.Unlock()
 	hdr := header(make([]byte, headerSize))
 	hdr.encode(typeWindowUpdate, flagRST, s.id, 0)
-	s.session.sendNoWait(hdr)
+	_ = s.session.sendNoWait(hdr)
 }
 
 // forceClose is used for when the session is exiting


### PR DESCRIPTION
It now passes:

- `golangci-lint run ./...`
- `go test -race ./... -short`

The `-short` is needed because both of `TestSendData_VeryLarge` and `TestSendData_Large` fail for timing reasons (since race mode is generally slower) and I was hesitant to rewrite them to be less timing sensitive, so I have them get skipped when in testing short mode for now.
