### PR TITLE
Fix yamux: Failed to read header server error

### DIFF
--- a/session.go
+++ b/session.go
@@ -555,7 +555,7 @@ func (s *Session) recvLoop() error {
 		// Read the header
 		if _, err := io.ReadFull(s.bufRead, hdr); err != nil {
 			if !errors.Is(err, io.EOF) && !strings.Contains(err.Error(), "closed") && !strings.Contains(err.Error(), "reset by peer") {
-				s.logger.Printf("[ERR] yamux: Failed to read header: %v (%T)", err, err)
+				s.logger.Printf("[ERR] yamux: Failed to read header: %v", err)
 			}
 			return err
 		}

--- a/session.go
+++ b/session.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -553,7 +554,7 @@ func (s *Session) recvLoop() error {
 	for {
 		// Read the header
 		if _, err := io.ReadFull(s.bufRead, hdr); err != nil {
-			if err != io.EOF && !strings.Contains(err.Error(), "closed") && !strings.Contains(err.Error(), "reset by peer") {
+			if !errors.Is(err, io.EOF) && !strings.Contains(err.Error(), "closed") && !strings.Contains(err.Error(), "reset by peer") {
 				s.logger.Printf("[ERR] yamux: Failed to read header: %v", err)
 			}
 			return err

--- a/session.go
+++ b/session.go
@@ -555,7 +555,7 @@ func (s *Session) recvLoop() error {
 		// Read the header
 		if _, err := io.ReadFull(s.bufRead, hdr); err != nil {
 			if !errors.Is(err, io.EOF) && !strings.Contains(err.Error(), "closed") && !strings.Contains(err.Error(), "reset by peer") {
-				s.logger.Printf("[ERR] yamux: Failed to read header: %v", err)
+				s.logger.Printf("[ERR] yamux: Failed to read header: %v (%T)", err, err)
 			}
 			return err
 		}


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

The `recvLoop` code checks websocket errors with `err != io.EOF`. This is ancient Go and not best practice. 
When using `coder/websocket` as underlying library as in our case, closed socket streams wrap errors (see https://github.com/coder/websocket/blob/d099e1621e8d0f080c9f3b87c5a8587e0b722723/frame.go#L52-L53):

```go
// Wrap wraps err with fmt.Errorf if err is non nil.
// Intended for use with defer and a named error return.
// Inspired by https://github.com/golang/go/issues/32676.
func Wrap(err *error, f string, v ...any) {
	if *err != nil {
		*err = fmt.Errorf(f+": %w", append(v, *err)...)
	}
}
```

To catch this error and guard against logging it the error comparison needs to use `errors.Is()` which is also modern Go. 

This takes care of https://github.com/hashicorp/yamux/issues/116#issuecomment-4224054753.