### PR TITLE
fix: make ErrTimeout Temporary and wrap ErrDeadlineExceeded

### DIFF
--- a/const.go
+++ b/const.go
@@ -6,6 +6,7 @@ package yamux
 import (
 	"encoding/binary"
 	"fmt"
+	"os"
 )
 
 // NetError implements net.Error
@@ -26,6 +27,18 @@ func (e *NetError) Timeout() bool {
 func (e *NetError) Temporary() bool {
 	return e.temporary
 }
+
+// Unwrap exposes the underlying error for errors.Is / errors.As.
+func (e *NetError) Unwrap() error {
+	return e.err
+}
+
+// deadlineReached keeps Error() == "i/o deadline reached" while unwrapping to
+// os.ErrDeadlineExceeded for net.Conn contract compatibility.
+type deadlineReached struct{}
+
+func (deadlineReached) Error() string { return "i/o deadline reached" }
+func (deadlineReached) Unwrap() error { return os.ErrDeadlineExceeded }
 
 var (
 	// ErrInvalidVersion means we received a frame with an
@@ -53,11 +66,15 @@ var (
 
 	// ErrTimeout is used when we reach an IO deadline
 	ErrTimeout = &NetError{
-		err: fmt.Errorf("i/o deadline reached"),
+		// Message stays "i/o deadline reached"; also wraps
+		// os.ErrDeadlineExceeded and reports Temporary so crypto/tls
+		// and net/http treat deadline reads as non-fatal (see #156).
+		err: deadlineReached{},
 
 		// Error should meet net.Error interface for timeouts for compatability
 		// with standard library expectations, such as http servers.
-		timeout: true,
+		timeout:   true,
+		temporary: true,
 	}
 
 	// ErrStreamClosed is returned when using a closed stream

--- a/const_test.go
+++ b/const_test.go
@@ -4,6 +4,9 @@
 package yamux
 
 import (
+	"errors"
+	"net"
+	"os"
 	"testing"
 )
 
@@ -71,5 +74,24 @@ func TestEncodeDecode(t *testing.T) {
 	}
 	if hdr.Length() != 4321 {
 		t.Fatalf("bad: %v", hdr)
+	}
+}
+
+func TestErrTimeoutNetErrorContract(t *testing.T) {
+	if ErrTimeout.Error() != "i/o deadline reached" {
+		t.Fatalf("Error() string changed: %q", ErrTimeout.Error())
+	}
+	if !ErrTimeout.Timeout() {
+		t.Fatalf("Timeout() should be true")
+	}
+	if !ErrTimeout.Temporary() {
+		t.Fatalf("Temporary() should be true for stdlib crypto/tls / http")
+	}
+	if !errors.Is(ErrTimeout, os.ErrDeadlineExceeded) {
+		t.Fatalf("expected errors.Is(ErrTimeout, os.ErrDeadlineExceeded)")
+	}
+	var ne net.Error
+	if !errors.As(ErrTimeout, &ne) || !ne.Timeout() {
+		t.Fatalf("expected net.Error with Timeout")
 	}
 }

--- a/session_test.go
+++ b/session_test.go
@@ -4,6 +4,7 @@
 package yamux
 
 import (
+	"os"
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -1027,6 +1028,14 @@ func TestReadDeadline(t *testing.T) {
 	// library's http server implementation.
 	if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
 		t.Fatalf("reading timeout error is expected to implement net.Error and return true when calling Timeout()")
+	}
+	// crypto/tls also requires Temporary() == true for deadline errors
+	// so hijacked connections are not torn down (#156).
+	if netErr, ok := err.(net.Error); !ok || !netErr.Temporary() {
+		t.Fatalf("reading timeout error is expected to return true when calling Temporary()")
+	}
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("expected errors.Is(err, os.ErrDeadlineExceeded); got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Description

Deadline errors from `Stream.Read` / `Write` implement `net.Error` with `Timeout() == true` but `Temporary() == false`, and do not wrap `os.ErrDeadlineExceeded`.

That breaks the `net.Conn` contract and causes `crypto/tls` (and similar stdlib code) to treat deadline reads as fatal — e.g. websocket upgrade over `tls.Conn` on a yamux `Stream` closes the connection.

## Fix

- `ErrTimeout.Temporary()` → `true`
- unwrap to `os.ErrDeadlineExceeded` via a small `deadlineReached` error type
- keep `Error()` string exactly `"i/o deadline reached"` (log/string stability)

## Tests

```bash
go test ./... -count=1
```

Added `TestErrTimeoutNetErrorContract` and extended the existing read-deadline assertions.

## Linked Issue

Closes #156
